### PR TITLE
chore: update vue

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "element-plus": "^2.1.10",
     "lodash": "^4.17.21",
     "uuid": "^8.3.2",
-    "vue": "^3.0.11",
+    "vue": "^3.2.33",
     "vuedraggable": "^4.0.1",
     "wangeditor": "^4.6.13"
   },
@@ -53,7 +53,6 @@
     "@vue/cli-plugin-router": "~4.5.0",
     "@vue/cli-plugin-typescript": "~4.5.0",
     "@vue/cli-service": "~4.5.0",
-    "@vue/compiler-sfc": "^3.0.11",
     "@vue/eslint-config-standard": "^5.1.2",
     "@vue/eslint-config-typescript": "^7.0.0",
     "babel-plugin-import": "^1.13.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,6 @@ specifiers:
   '@vue/cli-plugin-router': ~4.5.0
   '@vue/cli-plugin-typescript': ~4.5.0
   '@vue/cli-service': ~4.5.0
-  '@vue/compiler-sfc': ^3.0.11
   '@vue/eslint-config-standard': ^5.1.2
   '@vue/eslint-config-typescript': ^7.0.0
   ace-builds: ^1.4.12
@@ -33,7 +32,7 @@ specifiers:
   svg-sprite-loader: ^6.0.2
   typescript: ~4.1.5
   uuid: ^8.3.2
-  vue: ^3.0.11
+  vue: ^3.2.33
   vuedraggable: ^4.0.1
   wangeditor: ^4.6.13
 
@@ -58,9 +57,8 @@ devDependencies:
   '@vue/cli-plugin-babel': 4.5.17_95b4fdf657a0dbd24bb3d165d27ebcc4
   '@vue/cli-plugin-eslint': 4.5.17_66e28910525a36c0b6c9f5a4d333c57c
   '@vue/cli-plugin-router': 4.5.17_@vue+cli-service@4.5.17
-  '@vue/cli-plugin-typescript': 4.5.17_1bcedc8ad3f7bd553a5942a573d2997a
-  '@vue/cli-service': 4.5.17_2688d001c6b4bfb555b25bd0ac7949b7
-  '@vue/compiler-sfc': 3.2.33
+  '@vue/cli-plugin-typescript': 4.5.17_df07c5ff6783eefa9d39e65c8d511f56
+  '@vue/cli-service': 4.5.17_2aad0709d55cbf25514524d829a5644c
   '@vue/eslint-config-standard': 5.1.2_ca3b9a7706bc0be0ce26dca0d55db61b
   '@vue/eslint-config-typescript': 7.0.0_a4026fa076dd8f44e94f0e8ffbcc3f1d
   babel-plugin-import: 1.13.5
@@ -2007,7 +2005,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.9
       '@vue/babel-preset-app': 4.5.17_vue@3.2.33
-      '@vue/cli-service': 4.5.17_2688d001c6b4bfb555b25bd0ac7949b7
+      '@vue/cli-service': 4.5.17_2aad0709d55cbf25514524d829a5644c
       '@vue/cli-shared-utils': 4.5.17
       babel-loader: 8.2.4_598a497cebab8e15ee8f9e5632178e63
       cache-loader: 4.1.0_webpack@4.46.0
@@ -2026,7 +2024,7 @@ packages:
       '@vue/cli-service': ^3.0.0 || ^4.0.0-0
       eslint: '>= 1.6.0 < 7.0.0'
     dependencies:
-      '@vue/cli-service': 4.5.17_2688d001c6b4bfb555b25bd0ac7949b7
+      '@vue/cli-service': 4.5.17_2aad0709d55cbf25514524d829a5644c
       '@vue/cli-shared-utils': 4.5.17
       eslint: 6.8.0
       eslint-loader: 2.2.1_eslint@6.8.0+webpack@4.46.0
@@ -2044,11 +2042,11 @@ packages:
     peerDependencies:
       '@vue/cli-service': ^3.0.0 || ^4.0.0-0
     dependencies:
-      '@vue/cli-service': 4.5.17_2688d001c6b4bfb555b25bd0ac7949b7
+      '@vue/cli-service': 4.5.17_2aad0709d55cbf25514524d829a5644c
       '@vue/cli-shared-utils': 4.5.17
     dev: true
 
-  /@vue/cli-plugin-typescript/4.5.17_1bcedc8ad3f7bd553a5942a573d2997a:
+  /@vue/cli-plugin-typescript/4.5.17_df07c5ff6783eefa9d39e65c8d511f56:
     resolution: {integrity: sha512-7JeJ913td1xbNKcVO71clTEXWGq43/6FPLhph3kBEdUrMqANd1ENb4jFZ/Rl277YTFipV08WpzQ12d1ZtqwvEQ==}
     peerDependencies:
       '@vue/cli-service': ^3.0.0 || ^4.0.0-0
@@ -2059,9 +2057,8 @@ packages:
         optional: true
     dependencies:
       '@types/webpack-env': 1.16.4
-      '@vue/cli-service': 4.5.17_2688d001c6b4bfb555b25bd0ac7949b7
+      '@vue/cli-service': 4.5.17_2aad0709d55cbf25514524d829a5644c
       '@vue/cli-shared-utils': 4.5.17
-      '@vue/compiler-sfc': 3.2.33
       cache-loader: 4.1.0_webpack@4.46.0
       fork-ts-checker-webpack-plugin: 3.1.1
       globby: 9.2.0
@@ -2083,10 +2080,10 @@ packages:
     peerDependencies:
       '@vue/cli-service': ^3.0.0 || ^4.0.0-0
     dependencies:
-      '@vue/cli-service': 4.5.17_2688d001c6b4bfb555b25bd0ac7949b7
+      '@vue/cli-service': 4.5.17_2aad0709d55cbf25514524d829a5644c
     dev: true
 
-  /@vue/cli-service/4.5.17_2688d001c6b4bfb555b25bd0ac7949b7:
+  /@vue/cli-service/4.5.17_2aad0709d55cbf25514524d829a5644c:
     resolution: {integrity: sha512-MqfkRYIcIUACe3nYlzNrYstJTWRXHlIqh6JCkbWbdnXWN+IfaVdlG8zw5Q0DVcSdGvkevUW7zB4UhtZB4uyAcA==}
     engines: {node: '>=8'}
     hasBin: true
@@ -2124,7 +2121,6 @@ packages:
       '@vue/cli-plugin-router': 4.5.17_@vue+cli-service@4.5.17
       '@vue/cli-plugin-vuex': 4.5.17_@vue+cli-service@4.5.17
       '@vue/cli-shared-utils': 4.5.17
-      '@vue/compiler-sfc': 3.2.33
       '@vue/component-compiler-utils': 3.3.0
       '@vue/preload-webpack-plugin': 1.1.2_502c618fc8a7d35df07e93275324a2d0
       '@vue/web-component-wrapper': 1.3.0
@@ -2204,12 +2200,14 @@ packages:
       '@vue/shared': 3.2.33
       estree-walker: 2.0.2
       source-map: 0.6.1
+    dev: false
 
   /@vue/compiler-dom/3.2.33:
     resolution: {integrity: sha512-GhiG1C8X98Xz9QUX/RlA6/kgPBWJkjq0Rq6//5XTAGSYrTMBgcLpP9+CnlUg1TFxnnCVughAG+KZl28XJqw8uQ==}
     dependencies:
       '@vue/compiler-core': 3.2.33
       '@vue/shared': 3.2.33
+    dev: false
 
   /@vue/compiler-sfc/3.2.33:
     resolution: {integrity: sha512-H8D0WqagCr295pQjUYyO8P3IejM3vEzeCO1apzByAEaAR/WimhMYczHfZVvlCE/9yBaEu/eu9RdiWr0kF8b71Q==}
@@ -2224,12 +2222,14 @@ packages:
       magic-string: 0.25.9
       postcss: 8.4.12
       source-map: 0.6.1
+    dev: false
 
   /@vue/compiler-ssr/3.2.33:
     resolution: {integrity: sha512-XQh1Xdk3VquDpXsnoCd7JnMoWec9CfAzQDQsaMcSU79OrrO2PNR0ErlIjm/mGq3GmBfkQjzZACV+7GhfRB8xMQ==}
     dependencies:
       '@vue/compiler-dom': 3.2.33
       '@vue/shared': 3.2.33
+    dev: false
 
   /@vue/component-compiler-utils/3.3.0:
     resolution: {integrity: sha512-97sfH2mYNU+2PzGrmK2haqffDpVASuib9/w2/noxiFi31Z54hW+q3izKQXXQZSNhtiUpAI36uSuYepeBe4wpHQ==}
@@ -2260,7 +2260,7 @@ packages:
       '@vue/cli-service':
         optional: true
     dependencies:
-      '@vue/cli-service': 4.5.17_2688d001c6b4bfb555b25bd0ac7949b7
+      '@vue/cli-service': 4.5.17_2aad0709d55cbf25514524d829a5644c
       eslint: 6.8.0
       eslint-config-standard: 14.1.1_a3c9455a794a7c80c6cb4b867010bbe7
       eslint-import-resolver-node: 0.3.6
@@ -2311,6 +2311,7 @@ packages:
       '@vue/shared': 3.2.33
       estree-walker: 2.0.2
       magic-string: 0.25.9
+    dev: false
 
   /@vue/reactivity/3.2.33:
     resolution: {integrity: sha512-62Sq0mp9/0bLmDuxuLD5CIaMG2susFAGARLuZ/5jkU1FCf9EDbwUuF+BO8Ub3Rbodx0ziIecM/NsmyjardBxfQ==}
@@ -2345,6 +2346,7 @@ packages:
 
   /@vue/shared/3.2.33:
     resolution: {integrity: sha512-UBc1Pg1T3yZ97vsA2ueER0F6GbJebLHYlEi4ou1H5YL4KWvMOOWwpYo9/QpWq93wxKG6Wo13IY74Hcn/f7c7Bg==}
+    dev: false
 
   /@vue/web-component-wrapper/1.3.0:
     resolution: {integrity: sha512-Iu8Tbg3f+emIIMmI2ycSI8QcEuAUgPTgHwesDU1eKMLE4YC/c/sFbGc70QgMq31ijRftV0R7vCm9co6rldCeOA==}
@@ -4923,6 +4925,7 @@ packages:
 
   /estree-walker/2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+    dev: false
 
   /esutils/2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
@@ -6849,6 +6852,7 @@ packages:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
     dependencies:
       sourcemap-codec: 1.4.8
+    dev: false
 
   /make-dir/2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
@@ -7228,6 +7232,7 @@ packages:
     resolution: {integrity: sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+    dev: false
 
   /nanomatch/1.2.13:
     resolution: {integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==}
@@ -8249,6 +8254,7 @@ packages:
       nanoid: 3.3.3
       picocolors: 1.0.0
       source-map-js: 1.0.2
+    dev: false
 
   /posthtml-parser/0.2.1:
     resolution: {integrity: sha1-NdUw3jhnQMK6JP8usvrznM3ycd0=}
@@ -9123,6 +9129,7 @@ packages:
   /source-map-js/1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
+    dev: false
 
   /source-map-resolve/0.5.3:
     resolution: {integrity: sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==}
@@ -9163,6 +9170,7 @@ packages:
 
   /sourcemap-codec/1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
+    dev: false
 
   /spdx-correct/3.1.1:
     resolution: {integrity: sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==}


### PR DESCRIPTION
目前该库使用的`vue`版本较低，如果本地项目用的`vue`版本是最新版本的话，打包部署线上后会出现冲突错误。
最新版本的`vue`内置了`@vue/compiler-sfc`，所以可以不用引入了。
